### PR TITLE
Feature/cors config more

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,14 @@
             <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/com.github.ben-manes.caffeine/caffeine -->
+        <!-- Cache 구현체 -->
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>3.2.0</version>
+        </dependency>
+
         <!-- jwt -->
         <dependency>
             <groupId>io.jsonwebtoken</groupId>

--- a/src/main/java/com/nhnacademy/gateway/common/config/CacheConfig.java
+++ b/src/main/java/com/nhnacademy/gateway/common/config/CacheConfig.java
@@ -1,0 +1,24 @@
+package com.nhnacademy.gateway.common.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class CacheConfig {
+
+    @Bean
+    CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+        cacheManager.setCaffeine(
+                Caffeine.newBuilder()
+                        .expireAfterWrite(10, TimeUnit.MINUTES)
+                        .maximumSize(50)
+        );
+        return cacheManager;
+    }
+}

--- a/src/main/java/com/nhnacademy/gateway/common/config/CacheConfig.java
+++ b/src/main/java/com/nhnacademy/gateway/common/config/CacheConfig.java
@@ -8,16 +8,23 @@ import org.springframework.context.annotation.Configuration;
 
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Spring Cloud Eureka에서 사용할 캐시 구현체를 설정하는 구성 클래스입니다.
+ */
 @Configuration
 public class CacheConfig {
 
+    /**
+     * Caffeine 기반 캐시 매니저를 생성하여 반환합니다.
+     * 캐시 만료 시간과 최대 저장 항목 개수를 설정합니다.
+     */
     @Bean
     CacheManager cacheManager() {
         CaffeineCacheManager cacheManager = new CaffeineCacheManager();
         cacheManager.setCaffeine(
                 Caffeine.newBuilder()
-                        .expireAfterWrite(10, TimeUnit.MINUTES)
-                        .maximumSize(50)
+                        .expireAfterWrite(10, TimeUnit.MINUTES) // 캐시 만료 시간 설정
+                        .maximumSize(50) // 캐시에 저장할 최대 항목(키-값 쌍) 개수 설정
         );
         return cacheManager;
     }

--- a/src/main/java/com/nhnacademy/gateway/common/config/CorsConfig.java
+++ b/src/main/java/com/nhnacademy/gateway/common/config/CorsConfig.java
@@ -14,7 +14,7 @@ import org.springframework.web.reactive.config.WebFluxConfigurer;
 import java.util.List;
 
 /**
- * CORS 정책을 설정하는 Config 클래스입니다.
+ * CORS 정책을 설정하는 Config 클래스입니다. <br>
  * 해당 설정은 Spring Cloud Gateway의 전역 CORS 필터로 작동합니다.
  */
 @Slf4j

--- a/src/main/java/com/nhnacademy/gateway/common/config/CorsConfig.java
+++ b/src/main/java/com/nhnacademy/gateway/common/config/CorsConfig.java
@@ -1,7 +1,10 @@
 package com.nhnacademy.gateway.common.config;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.reactive.CorsWebFilter;
@@ -11,42 +14,61 @@ import org.springframework.web.reactive.config.WebFluxConfigurer;
 import java.util.List;
 
 /**
- * CORS 정책을 설정하는 Config 영역입니다.
+ * CORS 정책을 설정하는 Config 클래스입니다.
+ * 해당 설정은 Spring Cloud Gateway의 전역 CORS 필터로 작동합니다.
  */
+@Slf4j
 @Configuration
 public class CorsConfig implements WebFluxConfigurer {
 
+    @Value("${cors.allowed-origins}")
+    private List<String> allowedOrigins;
+
+    /**
+     * 전역 CORS 필터 Bean 등록 <br>
+     * - Gateway 수준에서 CORS를 제어하며, 각 라우터 또는 서비스 단의 설정과는 별도로 적용됩니다.
+     */
     @Bean
-    public CorsWebFilter corsFilter() {
+    CorsWebFilter corsFilter() {
         return new CorsWebFilter(corsConfigurationSource());
     }
 
     /**
-     * 특정 출처(origin)에서 오는 해당하는 HTTP Method 요청만 허용하도록 설정된 CORS 정책을 반환합니다.
+     * CORS 설정을 정의하고, 이를 특정 URL 경로에 매핑합니다.
+     *
+     * @return UrlBasedCorsConfigurationSource 정의된 CORS 정책을 URL 패턴에 적용하는 소스
      */
     UrlBasedCorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration corsConfig = new CorsConfiguration();
 
-        // cross-origin 요청이 허용되는 출처를 설정하십시오.
-        corsConfig.setAllowedOriginPatterns(List.of("*"));
+        // Cross-Origin-Resource Sharing 요청을 허용할 출처(origin)를 설정하는 패턴입니다
+        corsConfig.setAllowedOriginPatterns(allowedOrigins);
 
-        corsConfig.setAllowedHeaders(List.of("Content-Type", "X-USER-ID", "Authorization"));
+        // 클라이언트 요청 시 허용할 HTTP Header 목록
+        corsConfig.setAllowedHeaders(
+                List.of(
+                        HttpHeaders.CONTENT_TYPE,
+                        HttpHeaders.AUTHORIZATION,
+                        "X-USER-ID"  // 사용자 정의 헤더 예시
+                )
+        );
+
+        // 쿠키, 인증 정보 등을 포함한 요청 허용
         corsConfig.setAllowCredentials(true);
 
-        // 요청으로 허용하는 HTTP Methods를 설정하십시오.
+        // 허용할 HTTP Method 목록 설정
         corsConfig.setAllowedMethods(
                 List.of(
                         HttpMethod.GET.name(),
                         HttpMethod.POST.name(),
                         HttpMethod.PUT.name(),
                         HttpMethod.DELETE.name(),
-                        HttpMethod.OPTIONS.name()
+                        HttpMethod.OPTIONS.name() // Preflight 요청을 위함
                 )
         );
 
-        // 커스텀한 설정 값을 path에 매핑
-        UrlBasedCorsConfigurationSource source =
-                new UrlBasedCorsConfigurationSource();
+        // 정의된 CORS 설정을 모든 경로에 적용
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", corsConfig);
 
         return source;

--- a/src/main/java/com/nhnacademy/gateway/common/config/RouterConfig.java
+++ b/src/main/java/com/nhnacademy/gateway/common/config/RouterConfig.java
@@ -17,7 +17,7 @@ public class RouterConfig {
     private final JwtAuthorizationFilter jwtAuthorizationFilter;
 
     @Bean
-    public RouteLocator customRouteLocator(RouteLocatorBuilder builder) {
+    RouteLocator customRouteLocator(RouteLocatorBuilder builder) {
         return builder.routes()
                 .route("SENSOR-SERVICE",
                         r -> r

--- a/src/main/java/com/nhnacademy/gateway/common/config/RouterConfig.java
+++ b/src/main/java/com/nhnacademy/gateway/common/config/RouterConfig.java
@@ -19,38 +19,21 @@ public class RouterConfig {
     @Bean
     public RouteLocator customRouteLocator(RouteLocatorBuilder builder) {
         return builder.routes()
-                .route(
-                        "USER-SERVICE",
+                .route("SENSOR-SERVICE",
                         r -> r
-                                .path("/admin/**")
-                                .filters(f -> f.filter(jwtAuthorizationFilter))
-                                .uri("lb://USER-SERVICE")
+                                .path("/sensor-data-mappings/**")
+                                .uri("lb://SENSOR-SERVICE")
                 )
                 .route(
                         "USER-SERVICE",
                         r -> r
-                                .path("/users/**")
-                                .filters(f -> f.filter(jwtAuthorizationFilter))
-                                .uri("lb://USER-SERVICE")
-                )
-                .route(
-                        "USER-SERVICE",
-                        r -> r
-                                .path("/departments/**")
-                                .filters(f -> f.filter(jwtAuthorizationFilter))
-                                .uri("lb://USER-SERVICE")
-                )
-                .route(
-                        "USER-SERVICE",
-                        r -> r
-                                .path("/roles/**")
-                                .filters(f -> f.filter(jwtAuthorizationFilter))
-                                .uri("lb://USER-SERVICE")
-                )
-                .route(
-                        "USER-SERVICE",
-                        r -> r
-                                .path("/event-levels/**")
+                                .path(
+                                        "/admin/**",
+                                        "/departments/**",
+                                        "/users/**",
+                                        "/roles/**",
+                                        "/event-levels/**"
+                                )
                                 .filters(f -> f.filter(jwtAuthorizationFilter))
                                 .uri("lb://USER-SERVICE")
                 )

--- a/src/main/java/com/nhnacademy/gateway/common/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/nhnacademy/gateway/common/filter/JwtAuthorizationFilter.java
@@ -64,7 +64,7 @@ public class JwtAuthorizationFilter implements GatewayFilter {
 
         // 커스텀 헤더에 userId 담아서 요청 객체 수정
         ServerWebExchange mutatedExchange = exchange.mutate()
-                .request(builder -> builder.header("X-User-Id", userId))
+                .request(builder -> builder.header("X-USER-ID", userId))
                 .build();
 
         // 수정된 요청 전달

--- a/src/main/resources/application-release.properties
+++ b/src/main/resources/application-release.properties
@@ -1,10 +1,36 @@
 logging.level.root=info
 
+## ===============================
+## === [Gateway CORS Settings] ===
+## ===============================
+
+cors.allowed-origins=${GATEWAY_ALLOWED_ORIGIN_PATTERNS}
+
+## =============================================
+## === [Eureka Client Registration Settings] ===
+## =============================================
+
 eureka.client.register-with-eureka=true
 eureka.client.fetch-registry=true
+eureka.client.registry-fetch-interval-seconds=30
+eureka.client.disable-delta=true
+
 eureka.instance.prefer-ip-address=true
 eureka.instance.instance-id=${spring.application.name}:${server.port}
 
-eureka.client.service-url.defaultZone=${EUREKA_URL:http://admin:1234@localhost:10233/eureka}
+## ==================================================
+## === [Eureka Server Connection & Auth Settings] ===
+## ==================================================
+
+spring.security.user.name=${EUREKA_USERNAME}
+spring.security.user.password=${EUREKA_PASSWORD}
+eureka.port=${EUREKA_PORT}
+
+eureka.url=http://${spring.security.user.name}:${spring.security.user.password}@localhost:${eureka.port}/eureka
+eureka.client.service-url.defaultZone=${EUREKA_URL:${eureka.url}}
+
+## ======================
+## === [JWT Settings] ===
+## ======================
 
 jwt.secret=${JWT_SECRET}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,11 @@
 spring.application.name=spring-cloud-gateway
 server.port=10232
 
+spring.profiles.active=${SPRING_PROFILES_ACTIVE:dev}
 logging.file.name=logs/${spring.application.name}.log
+
+# Router Cache
+spring.cache.type=caffeine
 
 # 4-way Handshaking
 server.shutdown=graceful
@@ -12,10 +16,10 @@ spring.lifecycle.timeout-per-shutdown-phase=10s
 # Java RMI(Remote Method Invocation)
 logging.level.sun.rmi=off
 
-spring.profiles.active=${SPRING_PROFILES_ACTIVE:dev}
-
-logging.file.name=logs/eureka-gateway.log
+# Java JMX(Java Management Extensions)
+logging.level.javax.management=off
 
 # Spring Boot Actuator -> RESTful Web Service
 management.endpoints.web.exposure.include=health,info
-spring.webflux.base-path=/
+# management.endpoints.web.base-path=/
+# management.server.port=20464

--- a/src/test/java/com/nhnacademy/gateway/common/config/CorsConfigTest.java
+++ b/src/test/java/com/nhnacademy/gateway/common/config/CorsConfigTest.java
@@ -15,7 +15,7 @@ import java.net.URI;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-public class CorsConfigTest {
+class CorsConfigTest {
 
     CorsConfig corsConfig = new CorsConfig();
 


### PR DESCRIPTION
## 목차

1. CORS 출처를 허용하는 **Allowed-Origin-Patterns**를 `properties`로 설정할 수 있도록 구성 추가
2. Eureka Registry의 캐싱 작업 구현체를 추가
3. `RouterConfig` 내에 Route를 개선

---

### 1. **CORS Allowed-Origin-Patterns**를 `properties`로 설정하도록 추가

```java
corsConfig.setAllowedOriginPatterns(
    List.of(
        "http://localhost/*"
    )
);
```

- 위와 같이 코드 내부적으로 고정된 형식으로 지정하는 것이 아닌, `properties`로 주입할 수 있도록 추가

```java
    @Value("${cors.allowed-origins}")
    private List<String> allowedOrigins;
    
    // ...
    
    UrlBasedCorsConfigurationSource corsConfigurationSource() {
    
        // ...
        
        corsConfig.setAllowedOriginPatterns(allowedOrigins);
        
        // ...
    }
```

- 설정 값을 지정하는 방법은 아래와 같습니다.

```properties
# 단일
cors.allowed-origins=http://localhost/*
```

```properties
# 복합
cors.allowed-origins=http://localhost:*,http://localhost:8080/*
```

---

### 2. Eureka Registry 캐싱 구현체 추가

```java
@Configuration
public class CacheConfig {

    @Bean
    CacheManager cacheManager() {
        CaffeineCacheManager cacheManager = new CaffeineCacheManager();
        cacheManager.setCaffeine(
                Caffeine.newBuilder()
                        .expireAfterWrite(10, TimeUnit.MINUTES) // 캐시 만료 시간 설정
                        .maximumSize(50) // 캐시에 저장할 최대 항목(키-값 쌍) 개수 설정
        );
        return cacheManager;
    }
}
```

---

### 3. Spring Cloud Gateway의 **Route** 지정 방식을 개선

```java
@Bean
    RouteLocator customRouteLocator(RouteLocatorBuilder builder) {
        return builder.routes()
                .route(
                        "USER-SERVICE",
                        r -> r
                                .path("/admin/**")
                                .filters(f -> f.filter(jwtAuthorizationFilter))
                                .uri("lb://USER-SERVICE")
                )
                .route(
                        "USER-SERVICE",
                        r -> r
                                .path("/departments/**")
                                .filters(f -> f.filter(jwtAuthorizationFilter))
                                .uri("lb://USER-SERVICE")
                )
                .build();
    }
```

- 위와 같이 불필요한 **Route** 할당을 아래와 같이 효율적으로 구성

```java
@Bean
    RouteLocator customRouteLocator(RouteLocatorBuilder builder) {
        return builder.routes()
                .route(
                        "USER-SERVICE",
                        r -> r
                                .path(
                                        "/admin/**",
                                        "/departments/**"
                                )
                                .filters(f -> f.filter(jwtAuthorizationFilter))
                                .uri("lb://USER-SERVICE")
                )
                .build();
    }
```